### PR TITLE
Update CumulativeMedicationDurationFHIR4.cql

### DIFF
--- a/input/cql/CumulativeMedicationDurationFHIR4.cql
+++ b/input/cql/CumulativeMedicationDurationFHIR4.cql
@@ -453,7 +453,7 @@ First, we define a function that simply calculates CumulativeDuration of a set o
 intervals:
 */
 define function CumulativeDuration(Intervals List<Interval<DateTime>>):
-  Sum((collapse Intervals per day) X return all difference in days between start of X and end of X) + 1
+  Sum((collapse Intervals per day) X return all (difference in days between start of X and end of X) + 1)
 
 /*
 Next, we define a function that rolls out intervals:


### PR DESCRIPTION
Hi Bryn, per review request, please see recommended changes based on AU2022 updates. You can use CMS136v12 or CMS128v11 as references: https://ecqi.healthit.gov/sites/default/files/ecqm/measures/CMS136v12.html; https://ecqi.healthit.gov/sites/default/files/ecqm/measures/CMS128v11.html.

Please note:
- Line 132: The QDM version has three "ToDaily" functions - one takes "Quantity" as argument (QuantityToDaily), one takes "Code" as argument (CodeToDaily), and one takes choice of "Quantity" or "Code" (ToDaily). Deferring to eCQM standards team's recommendation on inclusion of timing.code for the FHIR version of this library.
- Recommended changes do not include minor AU2022 updates such as alias changes. 
- The FHIR version will have significantly different comments due to differences in data elements and calculation descriptions. Also, only a subset of library functions was used in AU2022 QDM measures; for functions not used in measures, comments were added to note that those were either still under development and should not be used, or that functions have not been particularly tested.

Thank you,
Dorothy Lee